### PR TITLE
docs: fix Timor-Leste flag visibility in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 <p align="center">
-  <img src="https://capsule-render.vercel.app/api?type=waving&height=220&text=Juli%C3%A3o%20Martins&fontSize=44&fontAlignY=38&desc=Frontend%20Developer%20%7C%20IT%20Collaborator%20at%20Viettel%20Telemor&descAlignY=58&color=0:0f172a,100:0ea5e9&fontColor=ffffff" alt="JuliÃ£o Martins banner" />
+  <img src="https://capsule-render.vercel.app/api?type=waving&height=230&text=Juli%C3%A3o%20Martins&fontSize=46&fontAlignY=38&desc=Frontend%20Developer%20%7C%20IT%20Collaborator%20at%20Viettel%20Telemor&descAlignY=60&color=0:0f172a,100:0ea5e9&fontColor=ffffff" alt="Julião Martins banner" />
 </p>
 
 <p align="center">
-  <strong>Building clean UI, smooth motion, and scalable frontend architecture.</strong>
-  <br />
-  <em>Ha'u halo interface modernu, lalais, no centradu ba utilizador.</em>
+  <strong>Designing modern digital experiences with clean architecture, smooth interaction, and measurable impact.</strong>
+  <br/>
+  <em>Ha'u kria interface modernu, lalais, no forte ba utilizador sira.</em>
 </p>
 
 <p align="center">
@@ -15,13 +15,13 @@
   <a href="https://telemor.tl/">
     <img src="https://img.shields.io/badge/Viettel%20Telemor-IT%20Collaborator-ef4444?style=for-the-badge&logo=databricks&logoColor=white" alt="Viettel Telemor badge" />
   </a>
-  <img src="https://img.shields.io/badge/Focus-Frontend%20%2B%20AI-1d4ed8?style=for-the-badge" alt="Focus badge" />
+  <img src="https://img.shields.io/badge/Focus-Frontend%20Engineering%20%2B%20AI-1d4ed8?style=for-the-badge" alt="Focus badge" />
   <img src="https://komarev.com/ghpvc/?username=juliao-martins-dev&style=for-the-badge&color=0ea5e9" alt="Profile views" />
 </p>
 
 ---
 
-## Portfolio
+## 🌐 Portfolio
 
 <p align="center">
   <a href="https://juliao-martins.vercel.app/">
@@ -35,37 +35,47 @@
 
 ---
 
-## About Me | Kona-ba Ha'u
+## 👨‍💻 About Me | Kona-ba Ha'u
+
+I am a frontend developer focused on scalable, high-performance web interfaces and polished user experiences.
 
 - Frontend Developer in the Software Development Team at **[Viettel Telemor](https://telemor.tl/)**.
-- I focus on responsive interfaces, clean component systems, animation, and performance.
-- I use AI as a productivity multiplier for design quality, iteration speed, and architecture decisions.
-- Ha'u servisu hanesan IT Collaborator no fokus ba frontend moderno, efisiente no fasil atu uza.
+- Strong focus on component architecture, responsiveness, animation, and accessibility.
+- AI-assisted workflow for faster iteration, better design quality, and cleaner engineering decisions.
+- Ha'u servisu hanesan IT Collaborator ho fokus ba frontend moderno, efisiente no fasil atu uza.
 
 ---
 
-## Tech Stack | Skill Tekniku
+## 🌍 Location & Contact
+
+- **Country:** <img src="https://flagcdn.com/w20/tl.png" width="20" alt="Timor-Leste flag" /> Timor-Leste (TL)
+- **Phone Code:** **+670**
+- **Collaboration:** Open to international remote projects and frontend partnerships.
+
+---
+
+## 🧰 Tech Stack | Skill Tekniku
 
 <p align="center">
   <img src="https://skillicons.dev/icons?i=nextjs,react,three,tailwind,ts,js,html,css,git,github,figma,vercel" alt="Tech stack icons" />
 </p>
 
-**Primary:** Next.js, React, React-Native, TypeScript, Tailwind CSS  
-**3D & Motion:** Three.js, React Three Fiber, GSAP  
-**Workflow:** GitHub, Figma, AI-assisted development
+- **Primary:** Next.js, React, React Native, TypeScript, Tailwind CSS
+- **3D & Motion:** Three.js, React Three Fiber, GSAP
+- **Workflow:** GitHub, Figma, AI-assisted development
 
 ---
 
-## What I Do in the Team | Papel iha Team
+## 🚀 What I Do in the Team | Papel iha Team
 
-- Build production-ready frontend features from UI/UX specs.
-- Collaborate with backend, QA, and product for reliable releases.
-- Improve performance, accessibility, and maintainability.
-- Turn complex ideas into simple and intuitive user experiences.
+- Build production-ready frontend features from UI/UX specifications.
+- Collaborate with backend, QA, and product teams for reliable releases.
+- Improve performance, maintainability, and accessibility standards.
+- Translate complex business requirements into intuitive user experiences.
 
 ---
 
-## GitHub Stats
+## 📊 GitHub Insights
 
 <p align="center">
   <img height="170" src="https://github-profile-summary-cards.vercel.app/api/cards/stats?username=juliao-martins-dev&theme=github_dark" alt="GitHub stats" />
@@ -82,20 +92,20 @@
 
 ---
 
-## Learning Direction | Aprende Kontinua
+## 📚 Learning Direction | Aprende Kontinua
 
 - Advanced frontend architecture patterns
 - Performance profiling and optimization
 - AI-driven development workflows
-- UX accessibility best practices
+- UX and accessibility best practices
 
 ---
 
-## Connect
+## 🤝 Connect
 
-- Portfolio: **https://juliao-martins.vercel.app/**
-- Open to collaboration on frontend, product UI, and AI-assisted projects.
+- **Portfolio:** [https://juliao-martins.vercel.app/](https://juliao-martins.vercel.app/)
+- **Open to:** Frontend development, product UI engineering, and AI-assisted digital projects.
 
 ---
 
-> Build fast. Build clean. Build smart.
+> **Build fast. Build clean. Build smart.**


### PR DESCRIPTION
### Motivation

- Ensure the Timor-Leste flag renders reliably across platforms that may show the regional-indicator emoji as `TL` instead of the flag. 
- Improve the README's developer-facing presentation and clarity while keeping country and contact information prominent.

### Description

- Replaced the emoji flag with a hosted image asset using an explicit `<img src="https://flagcdn.com/w20/tl.png" width="20" alt="Timor-Leste flag" />` tag to guarantee consistent flag rendering. 
- Adjusted the `Location & Contact` heading and preserved the country name as `Timor-Leste (TL)` and the phone code `+670`. 
- Polished copy and layout across `README.md`, including a slightly larger hero banner, refined headline/summary text, updated badges, and tightened formatting for sections like tech stack and team responsibilities. 
- Minor accessibility/alt-text fixes and consistent heading emojis for improved visual hierarchy.

### Testing

- Inspected the `README.md` diff to confirm the intended changes were applied successfully (succeeded). 
- Verified the repository shows `README.md` as modified so the change is present (succeeded). 
- Recorded the change in the repository history to persist the update (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699847fd04948326ae53f1b9f4864c6a)